### PR TITLE
Add License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,6 @@
-<This is where you put your License.  A sample license is shown below.>
-
 MIT License
 
-Copyright (c) 2022 Spencer Smith
+Copyright (c) 2022 Arkin Modi, Joy Xiao, Leon So, Timothy Choy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I've taken a quick look at a few licenses and I think the MIT License is good fit for us. The MIT License (1) lets people use our project for whatever they want, including commercially, and (2) will require people how use our project to credit us in their license.

Some other options:
- GNU
- Apache 2.0
- The Unlicense

https://choosealicense.com/licenses/

I'm also under the assumption that the line `A sample license is shown below` means we can remove Dr. Smith's MIT License.