### PR TITLE
[Rev 0 Demo] Seperate Registration Flow Into Individual Enpoints

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,10 +21,10 @@ model Employee {
   password    String
   image       String?
   type        UserType
-  shop_id     String?
+  shop_id     String
 
   appointments Appointment[]
-  shop         Shop?         @relation(fields: [shop_id], references: [id])
+  shop         Shop          @relation(fields: [shop_id], references: [id])
 
   @@index([shop_id])
 }
@@ -40,6 +40,7 @@ model Customer {
   image        String?
   type         UserType      @default(CUSTOMER)
   appointments Appointment[]
+  vehicles     Vehicle[]
 }
 
 // TODO: re-evaluate what should be optional for Appointment
@@ -85,7 +86,12 @@ model Vehicle {
   model         String
   vin           String
   license_plate String
+  customer_id   String
   appointment   Appointment[]
+
+  customer Customer @relation(fields: [customer_id], references: [id])
+
+  @@index([customer_id])
 }
 
 model WorkOrder {

--- a/src/pages/api/user/register/customer.ts
+++ b/src/pages/api/user/register/customer.ts
@@ -1,18 +1,11 @@
-/**
- * ******************
- * *** DEPRECATED ***
- * ******************
- */
-
+import {
+  createCustomer,
+  createCustomerSchema,
+  getUserByEmail,
+} from "@server/services/userService";
 import { NextApiRequest, NextApiResponse } from "next";
 
-import {
-  createUser,
-  getUserByEmail,
-  registrationSchema,
-} from "@server/services/userService";
-
-const registrationHandler = async (
+const registerCustomerHandler = async (
   req: NextApiRequest,
   res: NextApiResponse
 ) => {
@@ -21,7 +14,7 @@ const registrationHandler = async (
     return;
   }
 
-  const result = registrationSchema.safeParse(req.body);
+  const result = createCustomerSchema.safeParse(req.body);
   if (!result.success) {
     res.status(400).json({ message: result.error.issues });
     return;
@@ -33,9 +26,9 @@ const registrationHandler = async (
       .status(409)
       .json({ message: "User with email address already exists." });
   } else {
-    await createUser(result.data);
+    await createCustomer(result.data);
     res.redirect(req.body.callbackUrl ?? "/");
   }
 };
 
-export default registrationHandler;
+export default registerCustomerHandler;

--- a/src/pages/api/user/register/employee.ts
+++ b/src/pages/api/user/register/employee.ts
@@ -1,18 +1,11 @@
-/**
- * ******************
- * *** DEPRECATED ***
- * ******************
- */
-
+import {
+  createEmployee,
+  createEmployeeSchema,
+  getUserByEmail,
+} from "@server/services/userService";
 import { NextApiRequest, NextApiResponse } from "next";
 
-import {
-  createUser,
-  getUserByEmail,
-  registrationSchema,
-} from "@server/services/userService";
-
-const registrationHandler = async (
+const registerEmployeeHandler = async (
   req: NextApiRequest,
   res: NextApiResponse
 ) => {
@@ -21,7 +14,7 @@ const registrationHandler = async (
     return;
   }
 
-  const result = registrationSchema.safeParse(req.body);
+  const result = createEmployeeSchema.safeParse(req.body);
   if (!result.success) {
     res.status(400).json({ message: result.error.issues });
     return;
@@ -33,9 +26,9 @@ const registrationHandler = async (
       .status(409)
       .json({ message: "User with email address already exists." });
   } else {
-    await createUser(result.data);
+    await createEmployee(result.data);
     res.redirect(req.body.callbackUrl ?? "/");
   }
 };
 
-export default registrationHandler;
+export default registerEmployeeHandler;

--- a/src/pages/api/user/register/shopOwner.ts
+++ b/src/pages/api/user/register/shopOwner.ts
@@ -1,18 +1,11 @@
-/**
- * ******************
- * *** DEPRECATED ***
- * ******************
- */
-
+import {
+  createShopOwner,
+  createShopOwnerSchema,
+  getUserByEmail,
+} from "@server/services/userService";
 import { NextApiRequest, NextApiResponse } from "next";
 
-import {
-  createUser,
-  getUserByEmail,
-  registrationSchema,
-} from "@server/services/userService";
-
-const registrationHandler = async (
+const registerShopOwnerHandler = async (
   req: NextApiRequest,
   res: NextApiResponse
 ) => {
@@ -21,7 +14,7 @@ const registrationHandler = async (
     return;
   }
 
-  const result = registrationSchema.safeParse(req.body);
+  const result = createShopOwnerSchema.safeParse(req.body);
   if (!result.success) {
     res.status(400).json({ message: result.error.issues });
     return;
@@ -33,9 +26,9 @@ const registrationHandler = async (
       .status(409)
       .json({ message: "User with email address already exists." });
   } else {
-    await createUser(result.data);
+    await createShopOwner(result.data);
     res.redirect(req.body.callbackUrl ?? "/");
   }
 };
 
-export default registrationHandler;
+export default registerShopOwnerHandler;

--- a/src/server/db/client.ts
+++ b/src/server/db/client.ts
@@ -1,4 +1,11 @@
-import { PrismaClient, Service } from "@prisma/client";
+import {
+  Customer,
+  Employee,
+  PrismaClient,
+  Service,
+  Shop,
+  Vehicle,
+} from "@prisma/client";
 import { z } from "zod";
 
 declare global {
@@ -33,3 +40,11 @@ export type PartType = z.infer<typeof partSchema>;
 export type ServiceWithPartsType = {
   parts: PartType[];
 } & Service;
+
+export type CustomerWithVehicles = {
+  vehicles: Vehicle[];
+} & Customer;
+
+export type EmployeeWithShop = {
+  shop: Shop;
+} & Employee;

--- a/src/server/services/shopService.ts
+++ b/src/server/services/shopService.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const createShopSchema = z.object({});
+
+export type CreateShopType = z.infer<typeof createShopSchema>;

--- a/src/server/services/userService.ts
+++ b/src/server/services/userService.ts
@@ -1,6 +1,9 @@
-import { prisma, UserType } from "@server/db/client";
+import { Customer, Employee, prisma, UserType } from "@server/db/client";
+import { createShopSchema } from "@server/services/shopService";
+import { createVehicleSchema } from "@server/services/vehicleService";
 import { z } from "zod";
 
+// ********************** BEGIN DEPRECATED **********************
 export const registrationSchema = z.object({
   email: z.string().email(),
   password: z.string(),
@@ -9,37 +12,121 @@ export const registrationSchema = z.object({
   type: z.nativeEnum(UserType),
   shop: z.string().optional(),
 });
+
 export type CreateUserInputType = z.infer<typeof registrationSchema>;
 
-export const createUser = async (user: CreateUserInputType) => {
+export const createUser = async (
+  user: CreateUserInputType
+): Promise<Customer | Employee> => {
   if (user.type === "CUSTOMER") {
-    return await prisma.customer.create({
-      data: {
-        ...user,
+    return await createCustomer({
+      email: user.email,
+      password: user.password,
+      first_name: user.first_name,
+      last_name: user.last_name,
+      vehicle: {
+        license_plate: "TEST_LICENSE_PLATE",
+        make: "TEST_MAKE",
+        model: "TEST_MODEL",
+        vin: "TEST_VIN",
+        year: new Date().getFullYear(),
       },
     });
   } else {
-    const shop = user.shop
-      ? { shop: { connect: { id: user.shop } } }
-      : { shop: {} };
-
-    return await prisma.employee.create({
-      data: {
-        ...user,
-        ...shop,
-      },
+    return await createShopOwner({
+      email: user.email,
+      password: user.password,
+      first_name: user.first_name,
+      last_name: user.last_name,
+      shop: {},
     });
   }
 };
+// *********************** END DEPRECATED ***********************
 
-export const getUser = async (email: string) => {
+export const createCustomerSchema = z.object({
+  email: z.string().email(),
+  password: z.string(),
+  first_name: z.string(),
+  last_name: z.string(),
+  vehicle: createVehicleSchema,
+});
+
+export type CreateCustomerType = z.infer<typeof createCustomerSchema>;
+
+export const createCustomer = async (customer: CreateCustomerType) => {
+  return await prisma.customer.create({
+    data: {
+      email: customer.email,
+      password: customer.password,
+      first_name: customer.first_name,
+      last_name: customer.last_name,
+      type: "CUSTOMER",
+      vehicles: { create: { ...customer.vehicle } },
+    },
+  });
+};
+
+export const createEmployeeSchema = z.object({
+  email: z.string().email(),
+  password: z.string(),
+  first_name: z.string(),
+  last_name: z.string(),
+  shop_id: z.string(),
+});
+
+export type CreateEmployeeType = z.infer<typeof createEmployeeSchema>;
+
+export const createEmployee = async (employee: CreateEmployeeType) => {
+  // TODO: Check for shop
+  // const shop = await getShopById(employee.shop_id);
+  // if (!shop) return Promise.reject("Shop not found.");
+
+  return await prisma.employee.create({
+    data: {
+      email: employee.email,
+      password: employee.password,
+      first_name: employee.first_name,
+      last_name: employee.last_name,
+      type: "EMPLOYEE",
+      shop: { connect: { id: employee.shop_id } },
+    },
+  });
+};
+
+export const createShopOwnerSchema = z.object({
+  email: z.string().email(),
+  password: z.string(),
+  first_name: z.string(),
+  last_name: z.string(),
+  shop: createShopSchema,
+});
+
+export type CreateShopOwnerType = z.infer<typeof createShopOwnerSchema>;
+
+export const createShopOwner = async (shopOwner: CreateShopOwnerType) => {
+  return await prisma.employee.create({
+    data: {
+      email: shopOwner.email,
+      password: shopOwner.password,
+      first_name: shopOwner.first_name,
+      last_name: shopOwner.last_name,
+      type: "SHOP_OWNER",
+      shop: { create: { ...shopOwner.shop } },
+    },
+  });
+};
+
+export const getUserByEmail = async (
+  email: string
+): Promise<Customer | Employee | null> => {
   if (!email) return null;
   const user = await prisma.customer.findUnique({ where: { email } });
   return user ?? (await prisma.employee.findUnique({ where: { email } }));
 };
 
 export const authorize = async (email: string, password: string) => {
-  const userData = await getUser(email);
+  const userData = await getUserByEmail(email);
 
   if (!userData) return Promise.reject("user not found");
   if (userData.password !== password) return Promise.reject("unauthorized");

--- a/src/server/services/vehicleService.ts
+++ b/src/server/services/vehicleService.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const createVehicleSchema = z.object({
+  year: z.number().int(),
+  make: z.string(),
+  model: z.string(),
+  vin: z.string(),
+  license_plate: z.string(),
+});
+
+export type CreateVehicleType = z.infer<typeof createVehicleSchema>;

--- a/test/pages/api/user/register.integration.test.ts
+++ b/test/pages/api/user/register.integration.test.ts
@@ -5,23 +5,72 @@
  * @group integration
  */
 
-import { Employee } from "@server/db/client";
-
 import registrationHandler from "@pages/api/user/register";
-import { prisma } from "@server/db/client";
+import registerCustomerHandler from "@pages/api/user/register/customer";
+import registerEmployeeHandler from "@pages/api/user/register/employee";
+import registerShopOwnerHandler from "@pages/api/user/register/shopOwner";
+import {
+  CustomerWithVehicles,
+  Employee,
+  EmployeeWithShop,
+  prisma,
+} from "@server/db/client";
 import { createMockRequestResponse } from "@test/mocks/mockRequestResponse";
 
-const testEmployeeUser: Employee = {
-  id: "test_id",
-  first_name: "first_name",
-  last_name: "last_name",
-  email: "user@test.com",
-  password: "test_password",
+const testEmployee: Employee = {
+  id: "",
+  first_name: "employee_first_name",
+  last_name: "employee_last_name",
+  email: "employee@test.com",
+  password: "employee_password",
+  image: null,
+  create_time: new Date(),
+  update_time: new Date(),
+  type: "EMPLOYEE",
+  shop_id: "shop_id",
+};
+
+const testShopOwner: EmployeeWithShop = {
+  id: "",
+  first_name: "shop_owner_first_name",
+  last_name: "shop_owner_last_name",
+  email: "shop_owner@test.com",
+  password: "shop_owner_password",
   image: null,
   create_time: new Date(),
   update_time: new Date(),
   type: "SHOP_OWNER",
   shop_id: "shop_id",
+  shop: {
+    id: "shop_id",
+    create_time: new Date(),
+    update_time: new Date(),
+  },
+};
+
+const testCustomer: CustomerWithVehicles = {
+  id: "",
+  first_name: "customer_first_name",
+  last_name: "customer_last_name",
+  email: "customer@test.com",
+  password: "customer_password",
+  image: null,
+  create_time: new Date(),
+  update_time: new Date(),
+  type: "CUSTOMER",
+  vehicles: [
+    {
+      id: "test_customer_vehicle_id",
+      create_time: new Date(),
+      update_time: new Date(),
+      customer_id: "test_customer_id",
+      license_plate: "test_license_plate",
+      make: "test_make",
+      model: "test_model",
+      vin: "test_vin",
+      year: 2017,
+    },
+  ],
 };
 
 beforeAll(async () => {
@@ -43,30 +92,144 @@ describe("new user registration", () => {
     it("should create new user", async () => {
       const { req, res } = createMockRequestResponse({ method: "POST" });
       req.body = {
-        email: testEmployeeUser.email,
-        password: testEmployeeUser.password,
-        first_name: testEmployeeUser.first_name,
-        last_name: testEmployeeUser.last_name,
-        type: testEmployeeUser.type,
+        email: testEmployee.email,
+        password: testEmployee.password,
+        first_name: testEmployee.first_name,
+        last_name: testEmployee.last_name,
+        type: testEmployee.type,
       };
 
       await registrationHandler(req, res);
       const newUser = await prisma.employee.findUnique({
-        where: { email: testEmployeeUser.email },
+        where: { email: testEmployee.email },
       });
 
       expect(res.statusCode).toBe(302);
       expect(newUser).toEqual({
         id: expect.any(String),
-        first_name: "first_name",
-        last_name: "last_name",
-        email: "user@test.com",
-        password: "test_password",
+        first_name: testEmployee.first_name,
+        last_name: testEmployee.last_name,
+        email: testEmployee.email,
+        password: testEmployee.password,
         image: null,
         type: "SHOP_OWNER",
         create_time: expect.any(Date),
         update_time: expect.any(Date),
-        shop_id: null,
+        shop_id: expect.any(String),
+      });
+    });
+
+    it("should create new customer", async () => {
+      const { req, res } = createMockRequestResponse({ method: "POST" });
+      req.body = {
+        email: testCustomer.email,
+        password: testCustomer.password,
+        first_name: testCustomer.first_name,
+        last_name: testCustomer.last_name,
+        vehicle: {
+          year: testCustomer.vehicles[0]?.year,
+          make: testCustomer.vehicles[0]?.make,
+          model: testCustomer.vehicles[0]?.model,
+          vin: testCustomer.vehicles[0]?.vin,
+          license_plate: testCustomer.vehicles[0]?.license_plate,
+        },
+      };
+
+      await registerCustomerHandler(req, res);
+      const newCustomer = await prisma.customer.findUnique({
+        where: { email: testCustomer.email },
+        include: { vehicles: true },
+      });
+
+      expect(res.statusCode).toBe(302);
+      expect(newCustomer).toEqual({
+        id: expect.any(String),
+        first_name: testCustomer.first_name,
+        last_name: testCustomer.last_name,
+        email: testCustomer.email,
+        password: testCustomer.password,
+        image: null,
+        create_time: expect.any(Date),
+        update_time: expect.any(Date),
+        type: "CUSTOMER",
+        vehicles: [
+          {
+            id: expect.any(String),
+            create_time: expect.any(Date),
+            update_time: expect.any(Date),
+            year: testCustomer.vehicles[0]?.year,
+            make: testCustomer.vehicles[0]?.make,
+            model: testCustomer.vehicles[0]?.model,
+            vin: testCustomer.vehicles[0]?.vin,
+            license_plate: testCustomer.vehicles[0]?.license_plate,
+            customer_id: expect.any(String),
+          },
+        ],
+      });
+    });
+
+    it("should create new employee", async () => {
+      // Create Shop
+      // TODO: Use REST controller
+      const shop = await prisma.shop.create({ data: {} });
+      testEmployee.shop_id = shop.id;
+
+      const { req, res } = createMockRequestResponse({ method: "POST" });
+      req.body = {
+        email: testEmployee.email,
+        password: testEmployee.password,
+        first_name: testEmployee.first_name,
+        last_name: testEmployee.last_name,
+        shop_id: testEmployee.shop_id,
+      };
+
+      await registerEmployeeHandler(req, res);
+      const newEmployee = await prisma.employee.findUnique({
+        where: { email: testEmployee.email },
+      });
+
+      expect(res.statusCode).toBe(302);
+      expect(newEmployee).toEqual({
+        id: expect.any(String),
+        create_time: expect.any(Date),
+        update_time: expect.any(Date),
+        first_name: testEmployee.first_name,
+        last_name: testEmployee.last_name,
+        email: testEmployee.email,
+        password: testEmployee.password,
+        image: null,
+        type: testEmployee.type,
+        shop_id: testEmployee.shop_id,
+      });
+    });
+
+    it("should create new shop owner", async () => {
+      const { req, res } = createMockRequestResponse({ method: "POST" });
+      req.body = {
+        email: testShopOwner.email,
+        password: testShopOwner.password,
+        first_name: testShopOwner.first_name,
+        last_name: testShopOwner.last_name,
+        shop: {},
+      };
+
+      await registerShopOwnerHandler(req, res);
+      const newShopOwner = await prisma.employee.findUnique({
+        where: { email: testShopOwner.email },
+      });
+
+      expect(res.statusCode).toBe(302);
+      expect(newShopOwner).toEqual({
+        id: expect.any(String),
+        create_time: expect.any(Date),
+        update_time: expect.any(Date),
+        first_name: testShopOwner.first_name,
+        last_name: testShopOwner.last_name,
+        email: testShopOwner.email,
+        password: testShopOwner.password,
+        image: null,
+        type: testShopOwner.type,
+        shop_id: expect.any(String),
       });
     });
   });
@@ -75,21 +238,22 @@ describe("new user registration", () => {
     it("should not create new user", async () => {
       await prisma.employee.create({
         data: {
-          email: testEmployeeUser.email,
-          password: testEmployeeUser.password,
-          first_name: testEmployeeUser.first_name,
-          last_name: testEmployeeUser.last_name,
-          type: testEmployeeUser.type,
+          email: testEmployee.email,
+          password: testEmployee.password,
+          first_name: testEmployee.first_name,
+          last_name: testEmployee.last_name,
+          type: testEmployee.type,
+          shop: { create: {} },
         },
       });
 
       const { req, res } = createMockRequestResponse({ method: "POST" });
       req.body = {
-        email: testEmployeeUser.email,
-        password: testEmployeeUser.password,
-        first_name: testEmployeeUser.first_name,
-        last_name: testEmployeeUser.last_name,
-        type: testEmployeeUser.type,
+        email: testEmployee.email,
+        password: testEmployee.password,
+        first_name: testEmployee.first_name,
+        last_name: testEmployee.last_name,
+        type: testEmployee.type,
       };
 
       await registrationHandler(req, res);
@@ -105,9 +269,9 @@ describe("new user registration", () => {
     it("should return 400", async () => {
       const { req, res } = createMockRequestResponse({ method: "POST" });
       req.body = {
-        password: testEmployeeUser.password,
-        first_name: testEmployeeUser.first_name,
-        last_name: testEmployeeUser.last_name,
+        password: testEmployee.password,
+        first_name: testEmployee.first_name,
+        last_name: testEmployee.last_name,
       };
 
       await registrationHandler(req, res);

--- a/test/server/services/userService.test.ts
+++ b/test/server/services/userService.test.ts
@@ -4,14 +4,7 @@
  * @group unit
  */
 import { Employee } from "@prisma/client";
-import { PrismaClientKnownRequestError } from "@prisma/client/runtime";
-
-import {
-  authorize,
-  createUser,
-  CreateUserInputType,
-  getUser,
-} from "@server/services/userService";
+import { authorize, getUserByEmail } from "@server/services/userService";
 import { prismaMock } from "@test/mocks/prismaMock";
 
 const testEmployeeUser: Employee = {
@@ -32,7 +25,9 @@ describe("get user", () => {
     it("should return null", async () => {
       prismaMock.employee.findUnique.mockResolvedValue(null);
 
-      await expect(getUser("does_not_exists@test.com")).resolves.toBeNull();
+      await expect(
+        getUserByEmail("does_not_exists@test.com")
+      ).resolves.toBeNull();
     });
   });
 
@@ -40,7 +35,7 @@ describe("get user", () => {
     it("should return user", async () => {
       prismaMock.employee.findUnique.mockResolvedValue(testEmployeeUser);
 
-      await expect(getUser(testEmployeeUser.email)).resolves.toEqual(
+      await expect(getUserByEmail(testEmployeeUser.email)).resolves.toEqual(
         testEmployeeUser
       );
     });
@@ -48,38 +43,7 @@ describe("get user", () => {
 
   describe("given blank email address", () => {
     it("should return null", async () => {
-      await expect(getUser("")).resolves.toBeNull();
-    });
-  });
-});
-
-describe("create user", () => {
-  describe("given user", () => {
-    it("should create user", async () => {
-      const mockCreateUserInput: CreateUserInputType = testEmployeeUser;
-
-      prismaMock.employee.create.mockResolvedValue(testEmployeeUser);
-
-      await expect(createUser(mockCreateUserInput)).resolves.toBe(
-        testEmployeeUser
-      );
-    });
-  });
-
-  describe("given user already exists", () => {
-    it("should throw an exception", async () => {
-      const mockCreateUserInput: CreateUserInputType = testEmployeeUser;
-
-      prismaMock.employee.create.mockRejectedValue(
-        new PrismaClientKnownRequestError(
-          "Unique constraint failed on the constraint: `User_email_key`",
-          { code: "P2002", clientVersion: "4.7.0" }
-        )
-      );
-
-      await expect(createUser(mockCreateUserInput)).rejects.toBeInstanceOf(
-        PrismaClientKnownRequestError
-      );
+      await expect(getUserByEmail("")).resolves.toBeNull();
     });
   });
 });


### PR DESCRIPTION
I have left the current registration flow in place to not break anything. When @LeonSo7 updates the frontend to use the new endpoints, we can remove the old ones.

Relate https://github.com/arkinmodi/project-sayyara/issues/291
