### PR TITLE
[Rev 0 Demo] [Employee Management] Add employee management table

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -4,6 +4,7 @@ import {
   setIsLoggedIn,
   setUserSession,
 } from "@redux/actions/authActions";
+import { setShopEmployees } from "@redux/actions/shopActions";
 import { AuthSelectors } from "@redux/selectors/authSelectors";
 import styles from "@styles/components/common/Header.module.css";
 import classNames from "classnames";
@@ -134,6 +135,8 @@ const Header = () => {
           shopId: null,
         })
       );
+      // Reset shop state
+      dispatch(setShopEmployees({ employees: null }));
     }
   }, [session?.user, isLoggedIn, dispatch]);
 

--- a/src/components/employees/employeeTable.tsx
+++ b/src/components/employees/employeeTable.tsx
@@ -14,6 +14,7 @@ import {
 } from "primereact/datatable";
 import { Dialog } from "primereact/dialog";
 import { InputText } from "primereact/inputtext";
+import { Message } from "primereact/message";
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { ShopRoles } from "src/types/auth";
@@ -53,6 +54,7 @@ const EmployeeTable = () => {
 
   const employees = useSelector(ShopSelectors.getShopEmployees);
   const userType = useSelector(AuthSelectors.getUserType);
+  const shopId = useSelector(AuthSelectors.getShopId);
 
   const dispatch = useDispatch();
 
@@ -155,8 +157,20 @@ const EmployeeTable = () => {
   );
 
   return (
-    <div>
+    <div className={styles.employeeTableContainer}>
+      <Message
+        className={styles.inviteEmployeeMessage}
+        style={{
+          display:
+            userType === UserType.SHOP_OWNER && employeeList.length > 1
+              ? "inline-flex"
+              : "none",
+        }}
+        severity="info"
+        text={`To invite an employee, please provide them with your shop ID: ${shopId}`}
+      />
       <DataTable
+        className={styles.employeeTable}
         header={renderTableHeader()}
         value={employeeList}
         showGridlines
@@ -191,7 +205,6 @@ const EmployeeTable = () => {
           }}
         ></Column>
       </DataTable>
-
       <Dialog
         visible={showSuspendEmployeeDialog}
         style={{ width: "450px" }}

--- a/src/components/employees/employeeTable.tsx
+++ b/src/components/employees/employeeTable.tsx
@@ -1,0 +1,219 @@
+import { EmployeeStatus, UserType } from "@prisma/client";
+import { setEmployeeStatus } from "@redux/actions/employeeActions";
+import { readShopEmployees } from "@redux/actions/shopActions";
+import { AuthSelectors } from "@redux/selectors/authSelectors";
+import { ShopSelectors } from "@redux/selectors/shopSelector";
+import styles from "@styles/components/employees/EmployeeTable.module.css";
+import { FilterMatchMode, FilterOperator } from "primereact/api";
+import { Button } from "primereact/button";
+import { Column } from "primereact/column";
+import {
+  DataTable,
+  DataTableFilterMeta,
+  DataTableFilterMetaData,
+} from "primereact/datatable";
+import { Dialog } from "primereact/dialog";
+import { InputText } from "primereact/inputtext";
+import React, { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { ShopRoles } from "src/types/auth";
+import { IEmployee } from "src/types/employee";
+
+const EmployeeTable = () => {
+  const [employeeList, setEmployeeList] = useState<IEmployee[]>([]);
+  const [showSuspendEmployeeDialog, setShowSuspendEmployeeDialog] =
+    useState(false);
+  const [employeeToSuspend, setEmployeeToSuspend] = useState<IEmployee | null>(
+    null
+  );
+  const [filters, setFilters] = useState<DataTableFilterMeta>({
+    global: { value: null, matchMode: FilterMatchMode.CONTAINS },
+    firstName: {
+      operator: FilterOperator.AND,
+      constraints: [{ value: null, matchMode: FilterMatchMode.STARTS_WITH }],
+    },
+    lastName: {
+      operator: FilterOperator.AND,
+      constraints: [{ value: null, matchMode: FilterMatchMode.STARTS_WITH }],
+    },
+    id: {
+      operator: FilterOperator.AND,
+      constraints: [{ value: null, matchMode: FilterMatchMode.STARTS_WITH }],
+    },
+    phoneNumber: {
+      operator: FilterOperator.AND,
+      constraints: [{ value: null, matchMode: FilterMatchMode.STARTS_WITH }],
+    },
+    type: {
+      operator: FilterOperator.AND,
+      constraints: [{ value: null, matchMode: FilterMatchMode.STARTS_WITH }],
+    },
+  });
+  const [globalFilterValue, setGlobalFilterValue] = useState("");
+
+  const employees = useSelector(ShopSelectors.getShopEmployees);
+  const userType = useSelector(AuthSelectors.getUserType);
+
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(readShopEmployees());
+  }, [dispatch]);
+
+  useEffect(() => {
+    if (employees) {
+      const activeEmployees = employees.filter(
+        (employee) => employee.status === EmployeeStatus.ACTIVE
+      );
+      setEmployeeList(activeEmployees);
+    }
+  }, [employees]);
+
+  const handleSuspendEmployeeButton = (employee: IEmployee) => {
+    setShowSuspendEmployeeDialog(true);
+    setEmployeeToSuspend(employee);
+  };
+
+  const suspendEmployee = () => {
+    if (employeeToSuspend) {
+      dispatch(
+        setEmployeeStatus({
+          employeeId: employeeToSuspend.id,
+          status: EmployeeStatus.SUSPENDED,
+        })
+      );
+    }
+    setShowSuspendEmployeeDialog(false);
+  };
+
+  const suspendEmployeeButton = (employee: IEmployee) => {
+    return (
+      <React.Fragment>
+        {/**
+         * Hide suspend option for shop owner
+         */}
+        {employee.type === ShopRoles.EMPLOYEE ? (
+          <Button
+            icon="pi pi-trash"
+            className="p-button-text p-button-danger p-button-rounded"
+            // call the delete saga pass in the id
+            onClick={() => handleSuspendEmployeeButton(employee)}
+          />
+        ) : (
+          <></>
+        )}
+      </React.Fragment>
+    );
+  };
+
+  const hideSuspendEmployeeDialog = () => {
+    setShowSuspendEmployeeDialog(false);
+  };
+
+  const handleGlobalFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    let updatedFilters = { ...filters };
+    if (updatedFilters["global"]) {
+      (updatedFilters["global"] as DataTableFilterMetaData).value = value;
+
+      setFilters(updatedFilters);
+      setGlobalFilterValue(value);
+    }
+  };
+
+  const renderTableHeader = () => {
+    return (
+      <div className={styles.employeeTableHeader}>
+        <h2>Employees</h2>
+        <span className="p-input-icon-left">
+          <i className="pi pi-search" />
+          <InputText
+            value={globalFilterValue}
+            onChange={handleGlobalFilterChange}
+            placeholder="Keyword Search"
+          />
+        </span>
+      </div>
+    );
+  };
+
+  const suspendEmployeeDialogFooter = (
+    <React.Fragment>
+      <Button
+        label="No"
+        icon="pi pi-times"
+        className="p-button-text"
+        onClick={hideSuspendEmployeeDialog}
+      />
+      <Button
+        label="Yes"
+        icon="pi pi-check"
+        className="p-button-text"
+        onClick={suspendEmployee}
+      />
+    </React.Fragment>
+  );
+
+  return (
+    <div>
+      <DataTable
+        header={renderTableHeader()}
+        value={employeeList}
+        showGridlines
+        stripedRows
+        responsiveLayout="scroll"
+        emptyMessage="No employees found."
+        filters={filters}
+        filterDisplay="menu"
+        globalFilterFields={[
+          "id",
+          "name",
+          "firstName",
+          "lastName",
+          "type",
+          "phoneNumber",
+        ]}
+      >
+        <Column field="id" header="ID" sortable></Column>
+        <Column field="firstName" header="First Name" sortable></Column>
+        <Column field="lastName" header="Last Name" sortable></Column>
+        <Column field="email" header="Email" sortable></Column>
+        <Column field="phoneNumber" header="Phone Number"></Column>
+        <Column field="type" header="Role" sortable></Column>
+        <Column
+          body={(data) => suspendEmployeeButton(data)}
+          className={styles.suspendEmployeeButtonColumn}
+          style={{
+            display:
+              userType === UserType.SHOP_OWNER && employeeList.length > 1
+                ? "table-cell"
+                : "none",
+          }}
+        ></Column>
+      </DataTable>
+
+      <Dialog
+        visible={showSuspendEmployeeDialog}
+        style={{ width: "450px" }}
+        header="Confirm"
+        modal
+        footer={suspendEmployeeDialogFooter}
+        onHide={hideSuspendEmployeeDialog}
+      >
+        <div className="confirmation-content">
+          {employeeToSuspend && (
+            <div>
+              Are you sure you want to suspend{" "}
+              <b>
+                {employeeToSuspend.firstName} {employeeToSuspend.lastName}
+              </b>
+              ?
+            </div>
+          )}
+        </div>
+      </Dialog>
+    </div>
+  );
+};
+
+export default React.memo(EmployeeTable);

--- a/src/pages/shop/manage.tsx
+++ b/src/pages/shop/manage.tsx
@@ -3,6 +3,7 @@ import { getServerAuthSession } from "@server/common/getServerAuthSession";
 import { GetServerSideProps } from "next";
 import { TabPanel, TabView } from "primereact/tabview";
 import React from "react";
+import EmployeeTable from "src/components/employees/employeeTable";
 
 const ManageShopTabs = () => {
   return (
@@ -11,7 +12,7 @@ const ManageShopTabs = () => {
         {/* TODO: Add manage services page here */}
       </TabPanel>
       <TabPanel header="Employees">
-        {/* TODO: Add manage employees page here */}
+        <EmployeeTable />
       </TabPanel>
     </TabView>
   );

--- a/src/redux/actions/employeeActions.ts
+++ b/src/redux/actions/employeeActions.ts
@@ -1,0 +1,19 @@
+import { EmployeeStatus } from "@prisma/client";
+import EmployeeTypes from "@redux/types/employeeTypes";
+
+interface IEmployeeActionBase {
+  type: EmployeeTypes;
+}
+
+export interface IEmployeeActionSetEmployeeStatus extends IEmployeeActionBase {
+  payload: { employeeId: string; status: EmployeeStatus };
+}
+
+export type IEmployeeAction = IEmployeeActionSetEmployeeStatus;
+
+export const setEmployeeStatus = (
+  payload: IEmployeeActionSetEmployeeStatus["payload"]
+) => ({
+  type: EmployeeTypes.SET_EMPLOYEE_STATUS,
+  payload,
+});

--- a/src/redux/actions/shopActions.ts
+++ b/src/redux/actions/shopActions.ts
@@ -1,0 +1,30 @@
+import ShopTypes from "@redux/types/shopTypes";
+import { IEmployee } from "src/types/employee";
+
+interface IShopActionBase {
+  type: ShopTypes;
+}
+
+export interface IShopActionReadShopEmployees extends IShopActionBase {
+  payload: void;
+}
+
+export interface IShopActionSetShopEmployees extends IShopActionBase {
+  payload: { employees: IEmployee[] | null };
+}
+
+export type IShopAction =
+  | IShopActionReadShopEmployees
+  | IShopActionSetShopEmployees;
+
+export const readShopEmployees = (payload: void) => ({
+  type: ShopTypes.READ_SHOP_EMPLOYEES,
+  payload,
+});
+
+export const setShopEmployees = (
+  payload: IShopActionSetShopEmployees["payload"]
+) => ({
+  type: ShopTypes.SET_SHOP_EMPLOYEES,
+  payload,
+});

--- a/src/redux/reducers/rootReducer.ts
+++ b/src/redux/reducers/rootReducer.ts
@@ -1,8 +1,10 @@
 import { combineReducers } from "redux";
 import appointmentReducer from "./appointmentReducer";
 import authReducer from "./authReducer";
+import shopReducer from "./shopReducer";
 
 export const rootReducer = combineReducers({
   auth: authReducer,
   appointments: appointmentReducer,
+  shop: shopReducer,
 });

--- a/src/redux/reducers/shopReducer.ts
+++ b/src/redux/reducers/shopReducer.ts
@@ -1,0 +1,23 @@
+import { IShopAction } from "@redux/actions/shopActions";
+import { initialShopState } from "@redux/state/shop/shopState";
+import ShopTypes from "@redux/types/shopTypes";
+import { HYDRATE } from "next-redux-wrapper";
+import { IActionWithPayload } from "../actions/IActionWithPayload";
+
+const shopReducer = (
+  state = initialShopState,
+  action: IShopAction | IActionWithPayload<any>
+) => {
+  switch (action.type) {
+    case ShopTypes.SET_SHOP_EMPLOYEES:
+      return { ...state, employees: action?.payload?.employees };
+    // This will overwrite client state - required for Next.js
+    case HYDRATE: {
+      return { ...action.payload.shopReducer };
+    }
+    default:
+      return state;
+  }
+};
+
+export default shopReducer;

--- a/src/redux/sagas/employeeSaga.ts
+++ b/src/redux/sagas/employeeSaga.ts
@@ -1,0 +1,64 @@
+import { EmployeeStatus } from "@prisma/client";
+import { IEmployeeActionSetEmployeeStatus } from "@redux/actions/employeeActions";
+import EmployeeTypes from "@redux/types/employeeTypes";
+import ShopTypes from "@redux/types/shopTypes";
+import {
+  all,
+  call,
+  CallEffect,
+  put,
+  PutEffect,
+  takeEvery,
+} from "redux-saga/effects";
+
+interface IPatchEmployeeBody {
+  email?: string;
+  phone_number?: string;
+  status?: EmployeeStatus;
+  first_name?: string;
+  last_name?: string;
+}
+
+function patchEmployeeStatus(
+  employeeId: string,
+  body: IPatchEmployeeBody
+): Promise<boolean> {
+  return fetch(`/api/employee/${employeeId}`, {
+    method: "PATCH",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  }).then((res) => {
+    if (res.status === 200) {
+      return true;
+    } else {
+      // TODO: check and handle errors
+      return false;
+    }
+  });
+}
+
+function* updateEmployeeStatus(
+  action: IEmployeeActionSetEmployeeStatus
+): Generator<CallEffect | PutEffect> {
+  const body: IPatchEmployeeBody = { status: action.payload.status };
+  const success = yield call(
+    patchEmployeeStatus,
+    action.payload.employeeId,
+    body
+  );
+  if (success) {
+    yield put({ type: ShopTypes.READ_SHOP_EMPLOYEES });
+  }
+}
+
+/**
+ * Saga to handle all employee related actions.
+ */
+export function* employeeSaga() {
+  yield all([
+    takeEvery(EmployeeTypes.SET_EMPLOYEE_STATUS, updateEmployeeStatus),
+  ]);
+}

--- a/src/redux/sagas/rootSaga.ts
+++ b/src/redux/sagas/rootSaga.ts
@@ -1,7 +1,9 @@
 import { all } from "redux-saga/effects";
 import { appointmentSaga } from "./appointmentSaga";
 import { authSaga } from "./authSaga";
+import { employeeSaga } from "./employeeSaga";
+import { shopSaga } from "./shopSaga";
 
 export function* rootSaga() {
-  yield all([authSaga(), appointmentSaga()]);
+  yield all([authSaga(), appointmentSaga(), shopSaga(), employeeSaga()]);
 }

--- a/src/redux/sagas/shopSaga.ts
+++ b/src/redux/sagas/shopSaga.ts
@@ -1,0 +1,64 @@
+import { Employee } from "@prisma/client";
+import { AuthSelectors } from "@redux/selectors/authSelectors";
+import ShopTypes from "@redux/types/shopTypes";
+import {
+  all,
+  call,
+  CallEffect,
+  put,
+  PutEffect,
+  select,
+  SelectEffect,
+  takeEvery,
+} from "redux-saga/effects";
+import { IEmployee } from "src/types/employee";
+
+function getAllEmployees(shopId: string): Promise<IEmployee[] | null> {
+  return fetch(`/api/shop/${shopId}/employees`, {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+  }).then((res) => {
+    if (res.status === 200) {
+      return res.json().then((data) => {
+        const employees: IEmployee[] = data.map((employee: Employee) => {
+          return {
+            id: employee.id,
+            email: employee.email,
+            firstName: employee.first_name,
+            lastName: employee.last_name,
+            phoneNumber: employee.phone_number,
+            status: employee.status,
+            type: employee.type,
+          };
+        });
+        return employees;
+      });
+    } else {
+      // TODO: check and handle errors
+      return null;
+    }
+  });
+}
+
+function* readShopEmployees(): Generator<
+  CallEffect | PutEffect | SelectEffect
+> {
+  const shopId = (yield select(AuthSelectors.getShopId)) as string | null;
+  if (shopId) {
+    const employees = yield call(getAllEmployees, shopId);
+    yield put({
+      type: ShopTypes.SET_SHOP_EMPLOYEES,
+      payload: { employees },
+    });
+  }
+}
+
+/**
+ * Saga to handle all employee related actions.
+ */
+export function* shopSaga() {
+  yield all([takeEvery(ShopTypes.READ_SHOP_EMPLOYEES, readShopEmployees)]);
+}

--- a/src/redux/selectors/shopSelector.ts
+++ b/src/redux/selectors/shopSelector.ts
@@ -1,0 +1,14 @@
+import { IShopState } from "@redux/state/shop/shopState";
+import { createSelector } from "reselect";
+import { RootState } from "../store";
+
+const getShopState = (state: RootState): IShopState => state.shop;
+
+const getShopEmployees = createSelector(
+  getShopState,
+  (shopState) => shopState.employees
+);
+
+export const ShopSelectors = {
+  getShopEmployees,
+};

--- a/src/redux/state/shop/shopState.ts
+++ b/src/redux/state/shop/shopState.ts
@@ -1,0 +1,9 @@
+import { IEmployee } from "src/types/employee";
+
+export interface IShopState {
+  employees: IEmployee[] | null;
+}
+
+export const initialShopState: IShopState = {
+  employees: null,
+};

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -4,6 +4,7 @@ import { Store } from "redux";
 import createSagaMiddleware, { Task } from "redux-saga";
 import { rootReducer } from "./reducers/rootReducer";
 import { rootSaga } from "./sagas/rootSaga";
+import { initialShopState, IShopState } from "./state/shop/shopState";
 import {
   IAppointmentsState,
   initialAppointmentsState,
@@ -21,11 +22,13 @@ interface SagaStore extends Store {
 export interface RootState {
   auth: IAuthState;
   appointments: IAppointmentsState;
+  shop: IShopState;
 }
 
 const initialState = {
   auth: initialAuthState,
   appointments: initialAppointmentsState,
+  shop: initialShopState,
 };
 
 export const makeStore = (_context: Context) => {

--- a/src/redux/types/employeeTypes.ts
+++ b/src/redux/types/employeeTypes.ts
@@ -1,0 +1,5 @@
+enum EmployeeTypes {
+  SET_EMPLOYEE_STATUS = "SET EMPLOYEE STATUS",
+}
+
+export default EmployeeTypes;

--- a/src/redux/types/shopTypes.ts
+++ b/src/redux/types/shopTypes.ts
@@ -1,0 +1,6 @@
+enum ShopTypes {
+  READ_SHOP_EMPLOYEES = "READ EMPLOYEES",
+  SET_SHOP_EMPLOYEES = "SET EMPLOYEES",
+}
+
+export default ShopTypes;

--- a/src/styles/components/employees/EmployeeTable.module.css
+++ b/src/styles/components/employees/EmployeeTable.module.css
@@ -1,3 +1,14 @@
+.employeeTableContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.employeeTable {
+  width: 100%;
+}
+
 .employeeTableHeader {
   display: flex;
   flex-direction: row;
@@ -12,8 +23,22 @@
   text-align: center !important;
 }
 
-@media (max-width: 1000px) {
+.inviteEmployeeMessage {
+  background-color: #69ad96 !important;
+  background: #e4f8f0;
+  border: solid #69ad96 !important;
+  color: white !important;
+  margin-bottom: 10px;
+  opacity: 0.8;
+}
+
+.inviteEmployeeMessage > * {
+  color: white !important;
+}
+
+@media (max-width: 600px) {
   .employeeTableHeader {
     justify-content: center;
+    flex-direction: column;
   }
 }

--- a/src/styles/components/employees/EmployeeTable.module.css
+++ b/src/styles/components/employees/EmployeeTable.module.css
@@ -1,0 +1,19 @@
+.employeeTableHeader {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.suspendEmployeeButtonColumn {
+  display: flex;
+  min-width: 4em;
+  text-align: center !important;
+}
+
+@media (max-width: 1000px) {
+  .employeeTableHeader {
+    justify-content: center;
+  }
+}

--- a/src/types/employee.ts
+++ b/src/types/employee.ts
@@ -1,0 +1,11 @@
+import { EmployeeStatus, UserType } from "@prisma/client";
+
+export interface IEmployee {
+  id: string;
+  firstName: string;
+  lastName: string;
+  phoneNumber: string;
+  email: string;
+  type: UserType;
+  status: EmployeeStatus;
+}


### PR DESCRIPTION
[Rev 0 Demo] [Employee Management] Add employee management table

Close #301 
# Note
* Suspend option does not show for rows with employee type `SHOP_OWNER`
* Suspend option column does not show users logged in as `EMPLOYEE`
* Invitation instruction banner does not show users logged in as `EMPLOYEE`
* Only `ACTIVE` employees show on the table
* If table only includes one row, this means that the only employee is the `SHOP_OWNER`, and the suspend option column will not show

# Desktop
## Employee Management Table
<img width="3008" alt="image" src="https://user-images.githubusercontent.com/34189743/216746793-573d9c9b-95b4-4824-bd81-da89f21596d5.png">

# Mobile
<img width="392" alt="image" src="https://user-images.githubusercontent.com/34189743/216746840-e9080d48-2136-419d-9d65-965935e9890d.png">

## Suspend Employee Confirmation
For employee with name: `Employee Test`
<img width="692" alt="image" src="https://user-images.githubusercontent.com/34189743/216746203-a1036c5b-dd88-49dc-bbeb-614a26f24cb6.png">

